### PR TITLE
Added workaround for empty 'mac_addr' element in nodewatcher data.

### DIFF
--- a/ffmap/routertools.py
+++ b/ffmap/routertools.py
@@ -315,7 +315,6 @@ def parse_nodewatcher_xml(xml):
 			interface = {
 				"name": netif.xpath("name/text()")[0],
 				"mtu": int(netif.xpath("mtu/text()")[0]),
-				"mac": netif.xpath("mac_addr/text()")[0].lower(),
 				"traffic": {
 					"rx_bytes": int(netif.xpath("traffic_rx/text()")[0]),
 					"tx_bytes": int(netif.xpath("traffic_tx/text()")[0]),
@@ -329,6 +328,10 @@ def parse_nodewatcher_xml(xml):
 					interface["ipv6_addrs"].append(ipv6_addr.lower().split("/")[0])
 			with suppress(IndexError):
 				interface["ipv4_addr"] = netif.xpath("ipv4_addr/text()")[0]
+
+			with suppress(IndexError):
+				interface["mac"] = ""
+				interface["mac"] = netif.xpath("mac_addr/text()")[0].lower()
 			router_update["netifs"].append(interface)
 
 		visible_neighbours = 0

--- a/ffmap/web/filters.py
+++ b/ffmap/web/filters.py
@@ -117,6 +117,9 @@ def humanize_bytes(num, suffix='B'):
 
 @filters.app_template_filter('mac2fe80')
 def mac_to_ipv6_linklocal(mac):
+	if not mac:
+		return ''
+
 	# Remove the most common delimiters; dots, dashes, etc.
 	mac_bare = re.sub('[%s]+' % re.escape(' .:-'), '', mac)
 	mac_value = int(mac_bare, 16)


### PR DESCRIPTION
E.g. a OpenVPN tunnel, see interface ro1 https://monitoring.freifunk-franken.de/routers/5735f0aa9369c36338a41452