### PR TITLE
Fixed exception: caused by deleting a router without an owner

### DIFF
--- a/ffmap/web/application.py
+++ b/ffmap/web/application.py
@@ -63,7 +63,11 @@ def router_info(dbid):
 				flash("<b>Netmon Sync triggered!</b>", "success")
 				return redirect(url_for("router_info", dbid=dbid))
 			if request.form.get("act") == "delete":
-				if is_authorized(router["user"]["nickname"], session):
+				user = None
+				# a router may not have a owner, but admin users still can delete it
+				if ("user" in router) and ("nickname" in router["user"]):
+					user = router["user"]["nickname"]
+				if is_authorized(user, session):
 					db.routers.delete_one({"_id": ObjectId(dbid)})
 					flash("<b>Router <i>%s</i> deleted!</b>" % router["hostname"], "success")
 					return redirect(url_for("index"))

--- a/ffmap/web/helpers.py
+++ b/ffmap/web/helpers.py
@@ -75,7 +75,7 @@ def send_email(recipient, subject, content, sender="FFF Monitoring <noreply@moni
 	s.quit()
 
 def is_authorized(owner, session):
-	if owner == session.get("user"):
+	if ("user" in session) and (owner == session.get("user")):
 		return True
 	elif session.get("admin"):
 		return True


### PR DESCRIPTION
```
uWSGI exceptions catcher for "POST /routers/57d543db9369c37f3f6417a2" (request plugin: "python", modifier1: 0)

Exception: builtins.KeyError: 'user'

Exception class: builtins.KeyError

Exception message: 'user'

Backtrace:
filename: "/usr/lib/python3/dist-packages/flask/app.py" line: 1836 function: "__call__" text/code: "return self.wsgi_app(environ, start_response)" 
filename: "/usr/lib/python3/dist-packages/flask/app.py" line: 1820 function: "wsgi_app" text/code: "response = self.make_response(self.handle_exception(e))" 
filename: "/usr/lib/python3/dist-packages/flask/app.py" line: 1403 function: "handle_exception" text/code: "reraise(exc_type, exc_value, tb)" 
filename: "/usr/lib/python3/dist-packages/flask/_compat.py" line: 33 function: "reraise" text/code: "raise value" 
filename: "/usr/lib/python3/dist-packages/flask/app.py" line: 1817 function: "wsgi_app" text/code: "response = self.full_dispatch_request()" 
filename: "/usr/lib/python3/dist-packages/flask/app.py" line: 1477 function: "full_dispatch_request" text/code: "rv = self.handle_user_exception(e)" 
filename: "/usr/lib/python3/dist-packages/flask/app.py" line: 1381 function: "handle_user_exception" text/code: "reraise(exc_type, exc_value, tb)" 
filename: "/usr/lib/python3/dist-packages/flask/_compat.py" line: 33 function: "reraise" text/code: "raise value" 
filename: "/usr/lib/python3/dist-packages/flask/app.py" line: 1475 function: "full_dispatch_request" text/code: "rv = self.dispatch_request()" 
filename: "/usr/lib/python3/dist-packages/flask/app.py" line: 1461 function: "dispatch_request" text/code: "return self.view_functions[rule.endpoint](**req.view_args)" 
filename: "/usr/local/lib/python3.4/dist-packages/ffmap/web/application.py" line: 66 function: "router_info" text/code: "if is_authorized(router["user"]["nickname"], session):" 
```
The exception occurred, while deleting a router which does not belong to any user.
Even user with admin rights were not able to delete such a router.
The patch was already applied on our server.
