### PR TITLE
Added general exception handler for function 'import_nodewatcher_xml'

### DIFF
--- a/ffmap/routertools.py
+++ b/ffmap/routertools.py
@@ -107,6 +107,16 @@ def import_nodewatcher_xml(mac, xml):
 			}})
 		status = "unknown"
 		status_comment = "Integer Overflow"
+	except Exception as e:
+		import traceback
+		print("Warning: Exception occurred when saving %s: %s\n__%s" % (mac, e, traceback.format_exc().replace("\n", "\n__")))
+		if router:
+			db.routers.update_one({"_id": router_id}, {"$set": {
+				"status": "unknown",
+				"last_contact": utcnow()
+			}})
+		status = "unknown"
+		status_comment = "Exception occurred"
 
 	if router_id:
 		# fire events


### PR DESCRIPTION
A couple of days ago many routers were offline as an unhandled exception occurred in the 'import_nodewatcher_xml' function. Turns out, some user supplied invalid coordinates.
To be safe for any possible exception which can happen during the import of the XML data, I added a general exception handler.