### PR TITLE
Add hood-specific statistics

### DIFF
--- a/ffmap/db/stats.py
+++ b/ffmap/db/stats.py
@@ -7,3 +7,4 @@ db = client.freifunk
 
 # create capped collection
 db.create_collection("stats", capped=True, size=10*1024*1024, max=4320)
+db.create_collection("hoodstats", capped=True, size=10*1024*1024, max=4320)

--- a/ffmap/stattools.py
+++ b/ffmap/stattools.py
@@ -26,6 +26,23 @@ def router_status():
 		result[rs["_id"]] = rs["count"]
 	return result
 
+def total_clients_hood(selecthood):
+	r = db.routers.aggregate([{"$match": { "hood": selecthood }}, {"$group": {
+		"_id": None,
+		"clients": {"$sum": "$system.clients"}
+	}}])
+	return next(r)["clients"]
+
+def router_status_hood(selecthood):
+	r = db.routers.aggregate([{"$match": { "hood": selecthood }}, {"$group": {
+		"_id": "$status",
+		"count": {"$sum": 1}
+	}}])
+	result = {}
+	for rs in r:
+		result[rs["_id"]] = rs["count"]
+	return result
+
 def router_models():
 	r = db.routers.aggregate([{"$group": {
 		"_id": "$hardware.name",
@@ -36,8 +53,28 @@ def router_models():
 		result[rs["_id"]] = rs["count"]
 	return result
 
+def router_models_hood(selecthood):
+	r = db.routers.aggregate([{"$match": { "hood": selecthood }}, {"$group": {
+		"_id": "$hardware.name",
+		"count": {"$sum": 1}
+	}}])
+	result = {}
+	for rs in r:
+		result[rs["_id"]] = rs["count"]
+	return result
+
 def router_firmwares():
 	r = db.routers.aggregate([{"$group": {
+		"_id": "$software.firmware",
+		"count": {"$sum": 1}
+	}}])
+	result = {}
+	for rs in r:
+		result[rs["_id"]] = rs["count"]
+	return result
+
+def router_firmwares_hood(selecthood):
+	r = db.routers.aggregate([{"$match": { "hood": selecthood }}, {"$group": {
 		"_id": "$software.firmware",
 		"count": {"$sum": 1}
 	}}])
@@ -79,6 +116,16 @@ def record_global_stats():
 		"router_status": router_status(),
 		"total_clients": total_clients()
 	})
+
+def record_hood_stats():
+	allhoods = hoods()
+	for hood in allhoods:
+		db.hoodstats.insert_one({
+			"time": utcnow(),
+			"hood": hood,
+			"router_status": router_status_hood(hood),
+			"total_clients": total_clients_hood(hood)
+		})
 
 
 def router_user_sum():

--- a/ffmap/web/api.py
+++ b/ffmap/web/api.py
@@ -3,7 +3,7 @@
 from ffmap.routertools import *
 from ffmap.maptools import *
 from ffmap.dbtools import FreifunkDB
-from ffmap.stattools import record_global_stats
+from ffmap.stattools import record_global_stats, record_hood_stats
 
 from flask import Blueprint, request, make_response, redirect, url_for, jsonify, Response
 from pymongo import MongoClient
@@ -56,6 +56,7 @@ def alfred():
 		detect_offline_routers()
 		delete_orphaned_routers()
 		record_global_stats()
+		record_hood_stats()
 		update_mapnik_csv()
 	r.mimetype = 'application/json'
 	return r

--- a/ffmap/web/application.py
+++ b/ffmap/web/application.py
@@ -156,6 +156,7 @@ def user_info(nickname):
 def global_statistics():
 	hoods = stattools.hoods()
 	return render_template("statistics.html",
+		selecthood = "All Hoods",
 		stats = db.stats.find({}, {"_id": 0}),
 		clients = stattools.total_clients(),
 		router_status = stattools.router_status(),
@@ -164,6 +165,21 @@ def global_statistics():
 		hoods = hoods,
 		hoods_sum = stattools.hoods_sum(),
 		newest_routers = db.routers.find({"hardware.name": {"$ne": "Legacy"}}, {"hostname": 1, "hood": 1, "created": 1}).sort("created", pymongo.DESCENDING).limit(len(hoods)+1)
+	)
+
+@app.route('/hoodstatistics/<selecthood>')
+def global_hoodstatistics(selecthood):
+	hoods = stattools.hoods()
+	return render_template("statistics.html",
+		selecthood = selecthood,
+		stats = db.hoodstats.find({"hood": selecthood}, {"_id": 0, "hood": 0}),
+		clients = stattools.total_clients(),
+		router_status = stattools.router_status(),
+		router_models = stattools.router_models_hood(selecthood),
+		router_firmwares = stattools.router_firmwares_hood(selecthood),
+		hoods = hoods,
+		hoods_sum = stattools.hoods_sum(),
+		newest_routers = db.routers.find({"hardware.name": {"$ne": "Legacy"},"hood": selecthood}, {"hostname": 1, "hood": 1, "created": 1}).sort("created", pymongo.DESCENDING).limit(len(hoods)+1)
 	)
 
 @app.route('/register', methods=['GET', 'POST'])

--- a/ffmap/web/templates/statistics.html
+++ b/ffmap/web/templates/statistics.html
@@ -1,5 +1,5 @@
 {% extends "bootstrap.html" %}
-{% block title %}{{super()}} :: Statistics{% endblock %}
+{% block title %}{{super()}} :: Statistics for {{ selecthood }}{% endblock %}
 {% block head %}{{super()}}
 	<script src="{{ url_for('static', filename='js/graph/date.js') }}"></script>
 	<script src="{{ url_for('static', filename='js/graph/jquery.flot.js') }}"></script>
@@ -33,6 +33,15 @@
 				padding-right: 3px !important;
 			}
 		}
+		.table-hoods th {
+			text-align: center;
+		}
+		.table-hoods td {
+			text-align: center;
+		}
+		.table-hoods .firstrow {
+			text-align: left;
+		}
 	</style>
 {% endblock %}
 
@@ -42,32 +51,35 @@
 			<div class="panel panel-default">
 				<div class="panel-heading">Hoods</div>
 				<div class="panel-body">
-					<table class="table table-condensed">
+					<table class="table table-condensed table-hoods">
 						<tr>
-							<th>Hood</th>
+							<th class="firstrow">Hood</th>
 							<th class="success" title="Online Routers">Online</th>
 							<th class="danger" title="Offline Routers">Offline</th>
 							<th class="warning" title="Unknown Routers">Unknown</th>
 							<th class="active" title="Total Routers">Total</th>
 							<th class="info">Clients</th>
+							<th class="stats">Stats</th>
 						</tr>
 						{%- for hood, value in hoods|dictsort %}
 						<tr>
-							<td><a href="{{ url_for('router_list', q='hood:%s' % hood) }}">{{ hood }}</a></td>
+							<td class="firstrow"><a href="{{ url_for('router_list', q='hood:%s' % hood) }}">{{ hood }}</a></td>
 							<td class="success">{{ value["online"] or 0 }}</td>
 							<td class="danger">{{ value["offline"] or 0 }}</td>
 							<td class="warning">{{ value["unknown"] or 0 }}</td>
 							<td class="active">{{ hoods_sum[hood]["routers"] or 0 }}</td>
 							<td class="info">{{ hoods_sum[hood]["clients"] or 0 }}</td>
+							<td class="stats"><a href="{{ url_for('global_hoodstatistics', selecthood='%s' % hood) }}">Hood</a></td>
 						</tr>
 						{%- endfor %}
 						<tr>
-							<th>Sum</th>
+							<th class="firstrow">Sum</th>
 							<td class="success">{{ router_status.online or 0 }}</td>
 							<td class="danger">{{ router_status.offline or 0 }}</td>
 							<td class="warning">{{ router_status.unknown or 0 }}</td>
 							<td class="active">{{ (router_status.online or 0) + (router_status.offline or 0) + (router_status.unknown or 0) }}</td>
 							<td class="info">{{ clients }}</td>
+							<td class="stats"><a href="{{ url_for('global_statistics') }}">Global</a></td>
 						</tr>
 					</table>
 				</div>
@@ -75,7 +87,7 @@
 		</div>
 		<div class="col-xs-12 col-md-6">
 			<div class="panel panel-default">
-				<div class="panel-heading">Newest Routers</div>
+				<div class="panel-heading">Newest Routers @ {{ selecthood }}</div>
 				<div class="panel-body">
 					<div class="table-responsive">
 						<table class="table table-condensed">
@@ -100,7 +112,7 @@
 	<div class="row">
 		<div class="col-xs-12 col-md-6">
 			<div class="panel panel-default">
-				<div class="panel-heading">Routers</div>
+				<div class="panel-heading">Routers @ {{ selecthood }}</div>
 				<div class="panel-body">
 					<div id="globrouterstat" class="graph"></div>
 				</div>
@@ -108,7 +120,7 @@
 		</div>
 		<div class="col-xs-12 col-md-6">
 			<div class="panel panel-default">
-				<div class="panel-heading">Clients</div>
+				<div class="panel-heading">Clients @ {{ selecthood }}</div>
 				<div class="panel-body">
 					<div id="globclientstat" class="graph"></div>
 				</div>
@@ -118,7 +130,7 @@
 	<div class="row">
 		<div class="col-xs-12 col-md-6">
 			<div class="panel panel-default">
-				<div class="panel-heading">Routers Firmwares</div>
+				<div class="panel-heading">Router Firmwares @ {{ selecthood }}</div>
 				<div class="panel-body">
 					<div id="globrouterfwstat" class="graph"></div>
 				</div>
@@ -126,7 +138,7 @@
 		</div>
 		<div class="col-xs-12 col-md-6">
 			<div class="panel panel-default">
-				<div class="panel-heading">Routers Models</div>
+				<div class="panel-heading">Router Models @ {{ selecthood }}</div>
 				<div class="panel-body">
 					<div id="globroutermodelsstat" class="graph"></div>
 				</div>


### PR DESCRIPTION
If starting from an existing DB (init_db.py is NOT run), the
new collection 'hoodstats' has to be created manually.

In the init_db.py file, I used the same limits as for the stats collection:
db.create_collection("hoodstats", capped=True, size=10\*1024\*1024, max=4320)

Maybe it is better to increase those limits, as the hoodstats collection will have $hoods times the number of entries compared to the stats collection.