### PR TITLE
Use ULA for WebUI link

### DIFF
--- a/ffmap/web/filters.py
+++ b/ffmap/web/filters.py
@@ -180,6 +180,9 @@ def webui_addr(router_netifs):
 	try:
 		for br_mesh in filter(lambda n: n["name"] == "br-mesh", router_netifs):
 			for ipv6 in br_mesh["ipv6_addrs"]:
+				if ipv6.startswith("fd") and len(ipv6) > 25:
+					# This selects the first ULA address, if present
+					return ipv6
 				if ipv6.startswith("fdff") and len(ipv6) > 15 and len(ipv6) <= 20:
 					return ipv6
 	except (KeyError, TypeError):


### PR DESCRIPTION
For v2-hoods, the ULA should be used, which enables routing across
hoods.

Fixes #72 

Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>